### PR TITLE
Updates and Bug Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,39 +1,30 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '1.3.50'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.72'
 }
-
 group 'tk.tarajki'
 version '1.0-SNAPSHOT'
-
-sourceCompatibility = 1.8
-
 repositories {
     mavenCentral()
     maven {
         url 'https://papermc.io/repo/repository/maven-public/'
     }
 }
-
 dependencies {
-    compile group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: '1.3.50'
-    //https://papermc.io/javadocs/paper/1.14/overview-summary.html
-    compileOnly   group: 'com.destroystokyo.paper', name: 'paper-api', version: '1.14.4-R0.1-SNAPSHOT'
-
-    testCompile group: 'junit', name: 'junit', version: '4.12'
-}
-
-compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
-}
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    implementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: '1.3.72'
+    //https://papermc.io/javadocs/paper/1.16/overview-summary.html
+    compileOnly   group: 'com.destroystokyo.paper', name: 'paper-api', version: '1.16.1-R0.1-SNAPSHOT'
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.6.2")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.6.2")
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.6.2")
 }
 jar {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     manifest {
         attributes 'Main-Class': 'tk.tarajki.src.main.kotlin.Plugin'
     }
     from {
-        configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+        configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,6 @@
 main: Plugin
 name: FirstPlugin
 version: 1.0
+api-version: 1.16
 author: Taraj
 description: An Example plugin


### PR DESCRIPTION
Changes:
1. Updated the gradle version from 4.10.3 to 6.5.1 (And got rid of all warnings)
2. Updated the Kotlin version from 1.3.50 to 1.3.72
3. Updated junit version from 4.12 to 5.6.2
4. Updated paper-api version from 1.14.4 to 1.16.1
5. Specified api-version in plugin.yml to stop paper from enabling legacy support on plugin load.
6. Removed redundant sourceCompatibility, compileKotlin, and compileTestKotlin code.